### PR TITLE
Fix stylesheet link in aboutus.html

### DIFF
--- a/src/main/webapp/aboutus.html
+++ b/src/main/webapp/aboutus.html
@@ -19,7 +19,7 @@ limitations under the License.
   <head>
     <meta charset="UTF-8">
     <title>About Us</title>
-    <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="css/main.css">
   </head>
   </head>
     <nav>


### PR DESCRIPTION
The current link, "/css/main.css" is an absolute path, meaning it looks for a folder named "css" in this project's topmost directory. Instead, it should be "css/main.css", a relative path, which looks for a folder named "css" in the same directory as aboutus.html.