### PR TITLE
Added a simple regex to search for image links within a user's message

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -76,9 +76,14 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
-    Message message = new Message(user, text);
+    // Take any http links to png or jpg images and replace them as the source for an HTML 'img' tag
+    String regex = "(https?://\\S+\\.(png|jpg|gif))";
+    String replacement = "<img src=\"$1\" />";
+    String textWithImageReplaced = userText.replaceAll(regex, replacement);
+
+    Message message = new Message(user, textWithImageReplaced);
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + user);

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -40,6 +40,13 @@
   margin: 5px;
 }
 
+/* Restricts the size of images. */
+.message-body img {
+  display: block;
+  margin-top: 25px;
+  max-width: 75%;
+}
+
 /* Use this to hide certain elements like forms if the
    user is not logged in or viewing their own page. */
 .hidden {


### PR DESCRIPTION
Summary of PR:

- Added the regex inside the doPost() method of the MessageServlet file
- Updated the user-page css file to put a restriction on the image size
- Any image link that the user typed in is used as the source for an HTML 'img' tag. 

For example, if the user submits a message like:

"This is a cat pic: https://example.com/images/cat.jpg"

The data would be stored as:

"This is a cat pic: `<img src="https://example.com/images/cat.jpg"/>`"

So if the link is a valid link, the image should be rendered.