### PR TITLE
Added a regex to detect an image caption format in user text

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -23,6 +23,8 @@ import com.google.codeu.data.Message;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Pattern;
+
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -78,24 +80,41 @@ public class MessageServlet extends HttpServlet {
     String user = userService.getCurrentUser().getEmail();
     String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
-    // Regexes to detect images or video links
-    String imageRegex = "(https?://\\S+\\.(png|jpg|gif))";
-    String videoRegex = "(https?://\\S+\\.(mp4|webm|ogg|3gp))";
-
-    // If a link is found, this is what it would be replaced with
-    String imageReplacement = "<img src=\"$1\" alt=\"Couldn't load image\" />";
-    String videoReplacement = "\n<video width=\"320\" height=\"240\" controls loop>\n" + 
-                              "<source src=\"$1\" type=\"video/mp4\">\n" +
-                              "</video>";
-
-    // Replace any image or video links as <img> tags so they can be rendered on a website                      
-    String newText = userText.replaceAll(imageRegex, imageReplacement); 
-    newText = newText.replaceAll(videoRegex, videoReplacement);        
+    // Utilize helper method to replace any image links into html tags
+    String newText = detectAndReplaceMediaLinks(userText);
   
     // Store new text to the database
     Message message = new Message(user, newText);
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + user);
+  }
+
+  public String detectAndReplaceMediaLinks(String userText) {
+
+    String updatedText;
+
+    // Regexes to detect image links, video links, or image caption formats like ![caption here](/url/of/image.jpg)
+    String imageRegex = "(https?://\\S+\\.(png|jpg|gif))";
+    String videoRegex = "(https?://\\S+\\.(mp4|webm|ogg|3gp))";
+    String imageCaptionFormatRegex = "!{1}\\[{1}(.+)]{1}\\({1}(https?://\\S+\\.(png|jpg|gif))\\){1}";
+
+    // If a link is found, this is what it would be replaced with
+    String imageReplacement = "<img src=\"$1\" alt=\"Couldn't load image\" />";
+    String imageCaptionReplacement = "<figure>" + "<img src=\"$2\" alt=\"Couldn't load image\" />" + "<figcaption>$1</figcaption>" + "</figure>";
+    String videoReplacement = "<video width=\"320\" height=\"240\" controls loop>" + "<source src=\"$1\" type=\"video/mp4\">\n" + "</video>";
+  
+    // Check to see if the text contains a ![Caption Text](http//LinkToImage.jpg)
+    Boolean captionFormatIsFound = Pattern.compile(imageCaptionFormatRegex).matcher(userText).find();
+    if(captionFormatIsFound) {
+      updatedText = userText.replaceAll(imageCaptionFormatRegex, imageCaptionReplacement);
+    }
+    else {
+      // Replace any image or video links as <img> tags so they can be rendered on a website                      
+      updatedText = userText.replaceAll(imageRegex, imageReplacement); 
+      updatedText = updatedText.replaceAll(videoRegex, videoReplacement);        
+    }
+
+    return updatedText;
   }
 }

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -84,13 +84,13 @@ public class MessageServlet extends HttpServlet {
 
     // If a link is found, this is what it would be replaced with
     String imageReplacement = "<img src=\"$1\" alt=\"Couldn't load image\" />";
-    String videoReplacement = "\n<video width=\"320\" height=\"240\" controls>\n" + 
+    String videoReplacement = "\n<video width=\"320\" height=\"240\" controls loop>\n" + 
                               "<source src=\"$1\" type=\"video/mp4\">\n" +
                               "</video>";
 
     // Replace any image or video links as <img> tags so they can be rendered on a website                      
     String newText = userText.replaceAll(imageRegex, imageReplacement); 
-    newText = userText.replaceAll(videoRegex, videoReplacement);        
+    newText = newText.replaceAll(videoRegex, videoReplacement);        
   
     // Store new text to the database
     Message message = new Message(user, newText);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -104,7 +104,7 @@ public class MessageServlet extends HttpServlet {
    * @param userText is the incoming text that the user typed in before hitting "Submit"
    * @return the new text containing HTML content
    */
-  public String detectAndReplaceMediaLinks(String userText) {
+  private String detectAndReplaceMediaLinks(String userText) {
 
     String updatedText;
 

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -90,6 +90,20 @@ public class MessageServlet extends HttpServlet {
     response.sendRedirect("/user-page.html?user=" + user);
   }
 
+  /**
+   * This method defines some Regular Expressions (RegEx) to detect any URL's linking to images or videos.
+   * 
+   * If a URL link is found, the link in the string is replaced and stored with a <img> or <video> HTML tag so 
+   * that the link is rendered when the user page is refreshed.
+   * 
+   * If a format like '![caption here](/url/of/image.jpg)' is detected, the link will be stored in a <figure> HTML tag.
+   * This <figure> tag helps by putting both the image and text in one container.
+   * 
+   * If no links were found, the user text will not be affected.
+   * 
+   * @param userText is the incoming text that the user typed in before hitting "Submit"
+   * @return the new text containing HTML content
+   */
   public String detectAndReplaceMediaLinks(String userText) {
 
     String updatedText;

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -40,6 +40,9 @@
   margin: 5px;
 }
 
+/* Defines the dimensions of the figure container. 
+   Both an image and a figcaption will be 
+   encapsulated in one of these figure containers. */
 .message-body figure {
   border: thin #c0c0c0 solid;
   display: flex;
@@ -55,6 +58,8 @@
   max-height: 150px;
 }
 
+/* Defines the text style of the image caption.
+   Sets the font and centers the text. */
 .message-body figcaption {
   background-color: #222;
   color: #fff;

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -40,11 +40,27 @@
   margin: 5px;
 }
 
+.message-body figure {
+  border: thin #c0c0c0 solid;
+  display: flex;
+  flex-flow: column;
+  padding: 5px;
+  max-width: 220px;
+  margin: auto;
+}
+
 /* Restricts the size of images. */
 .message-body img {
-  display: block;
-  margin-top: 25px;
-  max-width: 75%;
+  max-width: 220px;
+  max-height: 150px;
+}
+
+.message-body figcaption {
+  background-color: #222;
+  color: #fff;
+  font: italic smaller sans-serif;
+  padding: 3px;
+  text-align: center;
 }
 
 /* Use this to hide certain elements like forms if the


### PR DESCRIPTION
Summary of PR:
- Created a helper method called 'detectAndReplaceMediaLinks()' to neatly group together the regex/replacement functionality
- When a user types in something like `![caption here](/url/of/image.jpg)`, a regex is used to detect this format and an HTML `<figure>` tag is used to render the image and place text underneath (like this http://i.imgur.com/bTrLhhg.jpg). 
- Updated the user-page CSS file to align the caption text underneath the image