### PR TITLE
Re-added a <body> tag that messed up our user-page

### DIFF
--- a/src/main/webapp/user-page.html
+++ b/src/main/webapp/user-page.html
@@ -24,6 +24,7 @@ limitations under the License.
     <script src="/js/user-page-loader.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Teko&display=swap" rel="stylesheet">
   </head>
+  <body onload="buildUI();">
     <nav>
       <ul id="navigation">
         <li><a href="home.html">Home</a></li>


### PR DESCRIPTION
Accidently approved a branch that had a missing `<body>` tag which broke the user-page html file. By re-adding this line of code, the user-page html file now loads properly.