### PR TITLE
Fixed bug that did not render user images in the public feed page

### DIFF
--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -1,69 +1,67 @@
 <!DOCTYPE html>
 <html>
-<head>
-<title>Message Feed</title>
-<link rel="stylesheet" href="/css/main.css">
-<link rel="stylesheet" href="/css/user-page.css">
-
-<script>
-  
-  // Fetch messages and add them to the page.
-  function fetchMessages(){
-    const url = '/feed';
-    fetch(url).then((response) => {
-      return response.json();
-    }).then((messages) => {
-      const messageContainer = document.getElementById('message-container');
-      if(messages.length == 0){
-        messageContainer.innerHTML = '<p>There are no posts yet.</p>';
+  <head>
+    <title>Message Feed</title>
+    <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="/css/user-page.css">
+    <script>
+      // Fetch messages and add them to the page.
+      function fetchMessages(){
+        const url = '/feed';
+        fetch(url).then((response) => {
+          return response.json();
+        }).then((messages) => {
+          const messageContainer = document.getElementById('message-container');
+          if(messages.length == 0){
+            messageContainer.innerHTML = '<p>There are no posts yet.</p>';
+          }
+          else{
+            messageContainer.innerHTML = '';  
+          }
+          messages.forEach((message) => {  
+            const messageDiv = buildMessageDiv(message);
+            messageContainer.appendChild(messageDiv);
+          });
+        });
       }
-      else{
-        messageContainer.innerHTML = '';  
+      
+      function buildMessageDiv(message){
+        const usernameDiv = document.createElement('div');
+        usernameDiv.classList.add("left-align");
+        usernameDiv.appendChild(document.createTextNode(message.user));
+        
+        const timeDiv = document.createElement('div');
+        timeDiv.classList.add('right-align');
+        timeDiv.appendChild(document.createTextNode(new Date(message.timestamp)));
+        
+        const headerDiv = document.createElement('div');
+        headerDiv.classList.add('message-header');
+        headerDiv.appendChild(usernameDiv);
+        headerDiv.appendChild(timeDiv);
+        
+        const bodyDiv = document.createElement('div');
+        bodyDiv.classList.add('message-body');
+        bodyDiv.innerHTML = message.text;
+        
+        const messageDiv = document.createElement('div');
+        messageDiv.classList.add("message-div");
+        messageDiv.appendChild(headerDiv);
+        messageDiv.appendChild(bodyDiv);
+        
+        return messageDiv;
       }
-      messages.forEach((message) => {  
-        const messageDiv = buildMessageDiv(message);
-        messageContainer.appendChild(messageDiv);
-      });
-    });
-  }
-  
-  function buildMessageDiv(message){
-    const usernameDiv = document.createElement('div');
-    usernameDiv.classList.add("left-align");
-    usernameDiv.appendChild(document.createTextNode(message.user));
-    
-    const timeDiv = document.createElement('div');
-    timeDiv.classList.add('right-align');
-    timeDiv.appendChild(document.createTextNode(new Date(message.timestamp)));
-    
-    const headerDiv = document.createElement('div');
-    headerDiv.classList.add('message-header');
-    headerDiv.appendChild(usernameDiv);
-    headerDiv.appendChild(timeDiv);
-    
-    const bodyDiv = document.createElement('div');
-    bodyDiv.classList.add('message-body');
-    bodyDiv.innerHTML = message.text;
-    
-    const messageDiv = document.createElement('div');
-    messageDiv.classList.add("message-div");
-    messageDiv.appendChild(headerDiv);
-    messageDiv.appendChild(bodyDiv);
-    
-    return messageDiv;
-  }
-  
-  // Fetch data and populate the UI of the page.
-  function buildUI(){
-    fetchMessages();
-  }
-</script>
-</head>
-<body onload="buildUI()">
- <div id="content">
-  <h1>Message Feed</h1>
-  <hr/>
-  <div id="message-container">Loading...</div>
- </div>
-</body>
+      
+      // Fetch data and populate the UI of the page.
+      function buildUI(){
+        fetchMessages();
+      }
+    </script>
+  </head>
+  <body onload="buildUI()">
+    <div id="content">
+      <h1>Message Feed</h1>
+      <hr/>
+      <div id="message-container">Loading...</div>
+    </div>
+  </body>
 </html>

--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -41,6 +41,8 @@
         
         const bodyDiv = document.createElement('div');
         bodyDiv.classList.add('message-body');
+        // Sets this div's content to be what was read from Datastore
+        // Makes it so that any HTML tags are appended onto this div and not just treated as text
         bodyDiv.innerHTML = message.text;
         
         const messageDiv = document.createElement('div');

--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -43,7 +43,7 @@
     
     const bodyDiv = document.createElement('div');
     bodyDiv.classList.add('message-body');
-    bodyDiv.appendChild(document.createTextNode(message.text));
+    bodyDiv.innerHTML = message.text;
     
     const messageDiv = document.createElement('div');
     messageDiv.classList.add("message-div");


### PR DESCRIPTION
Before making this change, the public feed was not rendering `<img>` tags and was showing them as if they were text. By making this change, that issue no longer happens and the images or videos are rendered correctly.